### PR TITLE
Fix: Icinga for Windows integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ For easier usage, the plugin is designed to work as replacement for the `PowerSh
 
 * Installed [PowerShell for Linux](https://docs.microsoft.com/de-de/powershell/scripting/install/installing-powershell-on-linux)
 * Configured WinRM service on the Windows machines
-* [Icinga for Windows](https://icinga.com/docs/icinga-for-windows/latest/) installed on the Windows machines
+* [Icinga for Windows](https://icinga.com/docs/icinga-for-windows/latest/) >=1.8.0 installed on the Windows machines
 
 ## Usage
 

--- a/docs/10-Changelog.md
+++ b/docs/10-Changelog.md
@@ -1,0 +1,11 @@
+# Check By Icinga for Windows CHANGELOG
+
+**The latest release announcements are available on [https://icinga.com/blog/](https://icinga.com/blog/).**
+
+Released closed milestones can be found on [GitHub](https://github.com/LordHepipud/check_by_icingaforwindows/milestones?state=closed).
+
+## 1.0.0 (2022-02-08)
+
+[Issue and PRs](https://github.com/LordHepipud/check_by_icingaforwindows/milestone/1?closed=1)
+
+* Initial Release


### PR DESCRIPTION
Fixes Icinga for Windows integration by using a custom feature set to receive plugin output and exit code directly from the remote PowerShell, regardless of native PowerShell or JEA PowerShell and increase performance for plugin execution.

Requires Icinga for Windows v1.8.0 or later.